### PR TITLE
Remove demo page link from navigation

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -110,10 +110,6 @@ const config: Config = {
               label: 'npm Package',
               href: 'https://www.npmjs.com/package/chatbot-flow-editor',
             },
-            {
-              label: 'Demo',
-              href: 'https://enumura1.github.io/chatbot-flow-editor/demo',
-            },
           ],
         },
         {


### PR DESCRIPTION
## What Changed
- Removed demo page link from Links dropdown in navbar

## Testing
- [ ] Added new tests
- [ ] Existing tests pass
- [x] Manually tested the changes

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Additional Notes
- This prevents users from clicking on a non-existent demo page
