### PR TITLE
fix: display hierarchy paths instead of node IDs in FlowDiagram

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -10,6 +10,8 @@ apps/
 vite.config.ts
 tsconfig.json
 tsconfig.*.json
+index.html
+src/main.tsx
 
 # Source files (since we ship dist/)
 src/

--- a/packages/core/index.html
+++ b/packages/core/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chatbot Flow Editor - Development</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,10 +10,7 @@
   "main": "./dist/index.js",
   "files": [
     "dist",
-    "bin",
-    "src",
-    "index.html",
-    "vite.config.ts"
+    "bin"
   ],
   "scripts": {
     "editor": "vite --port 4001 --open",

--- a/packages/core/src/components/chatbot-editor/FlowDiagram.tsx
+++ b/packages/core/src/components/chatbot-editor/FlowDiagram.tsx
@@ -25,29 +25,29 @@ const FlowDiagram: React.FC<FlowDiagramProps> = ({
   const buildHierarchy = (): TreeNode | null => {
     const rootNode = flow.find(node => node.id === 1);
     if (!rootNode) return null;
-    
+
     // Create node map for quick lookup
     const nodeMap = flow.reduce<Record<number, ChatNode>>((map, node) => {
       map[node.id] = node;
       return map;
     }, {});
-    
+
     // Track visited nodes to prevent circular references
     const visited = new Set<number>();
-    
+
     // Recursively build node tree
     const buildNodeTree = (nodeId: number, depth: number, index: number): TreeNode | null => {
       // Check for circular references
       if (visited.has(nodeId)) return null;
       visited.add(nodeId);
-      
+
       const node = nodeMap[nodeId];
       if (!node) return null;
-      
+
       const children = node.options
         .map((option, idx) => buildNodeTree(option.nextId, depth + 1, idx))
         .filter((child): child is TreeNode => child !== null);
-      
+
       return {
         node,
         depth,
@@ -55,14 +55,17 @@ const FlowDiagram: React.FC<FlowDiagramProps> = ({
         children
       };
     };
-    
+
     return buildNodeTree(rootNode.id, 0, 0);
   };
-  
+
   // Recursively render node from hierarchy
   const renderNode = (item: TreeNode): React.ReactElement => {
     const { node, depth, children } = item;
-    
+
+    // Debug log to check hierarchyPath
+    console.log(`FlowDiagram renderNode - Node ID: ${node.id}, hierarchyPath: ${node.hierarchyPath}`);
+
     return (
       <div key={node.id} className="flex flex-col mb-8">
         <div className="flex items-start">
@@ -75,37 +78,45 @@ const FlowDiagram: React.FC<FlowDiagramProps> = ({
               <div className="w-10 h-10 border-b-4 border-l-4 border-gray-500 mr-3"></div>
             </>
           )}
-          
+
           {/* Node */}
-          <div 
+          <div
             className={`px-5 py-3 rounded-lg shadow-md cursor-pointer border-2
-              ${currentNodeId === node.id 
-                ? 'bg-blue-50 border-blue-600 ring-2 ring-blue-200' 
+              ${currentNodeId === node.id
+                ? 'bg-blue-50 border-blue-600 ring-2 ring-blue-200'
                 : 'bg-white border-gray-300'}`}
             style={{ minWidth: '240px' }}
             onClick={() => onNodeSelect(node.id)}
           >
-            {/* Node ID - small display */}
-            <div className="text-xs font-medium text-gray-600 mb-1">Node {node.id}</div>
-            
+            {/* Node ID - display hierarchyPath if available, otherwise fallback to node.id */}
+            <div className="text-xs font-medium text-gray-600 mb-1">
+              Node {node.hierarchyPath || node.id}
+            </div>
+
             {/* Node title - larger, more prominent */}
             <div className="text-base font-bold text-gray-900 mb-2 truncate">{node.title}</div>
-            
+
             {/* Options - improved visibility */}
             {node.options.length > 0 && (
               <div className="text-sm text-gray-800 mt-2 border-t border-gray-300 pt-2">
-                {node.options.map((option, optIdx) => (
-                  <div key={optIdx} className="flex items-center py-1.5">
-                    <span className="mr-2 text-blue-600 font-bold">•</span>
-                    <span className="truncate font-medium flex-1">{option.label}</span>
-                    <span className="text-xs bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded ml-2 whitespace-nowrap">→ Node {option.nextId}</span>
-                  </div>
-                ))}
+                {node.options.map((option, optIdx) => {
+                  // Find the target node to get its hierarchyPath
+                  const targetNode = flow.find(n => n.id === option.nextId);
+                  const targetDisplay = targetNode?.hierarchyPath || option.nextId;
+                  
+                  return (
+                    <div key={optIdx} className="flex items-center py-1.5">
+                      <span className="mr-2 text-blue-600 font-bold">•</span>
+                      <span className="truncate font-medium flex-1">{option.label}</span>
+                      <span className="text-xs bg-gray-100 text-gray-700 px-1.5 py-0.5 rounded ml-2 whitespace-nowrap">→ Node {targetDisplay}</span>
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>
         </div>
-        
+
         {children.length > 0 && (
           <div className="flex flex-col ml-10 mt-3">
             {children.map(child => renderNode(child))}
@@ -114,9 +125,9 @@ const FlowDiagram: React.FC<FlowDiagramProps> = ({
       </div>
     );
   };
-  
+
   const hierarchy = buildHierarchy();
-  
+
   return (
     <ScrollArea className="h-full w-full">
       <div className="p-6">

--- a/packages/core/src/components/chatbot-editor/index.tsx
+++ b/packages/core/src/components/chatbot-editor/index.tsx
@@ -27,21 +27,21 @@ const initialFlow: ChatbotFlow = [
   },
   {
     id: 2,
-    title: "Node 2 content",
+    title: "Node 1 title",
     options: [],
     parentId: 1,
     hierarchyPath: "1-1"
   },
   {
     id: 3,
-    title: "Node 3 content",
+    title: "Node 2 title",
     options: [],
     parentId: 1,
     hierarchyPath: "1-2"
   },
   {
     id: 4,
-    title: "Node 4 content",
+    title: "Node 3 title",
     options: [],
     parentId: 1,
     hierarchyPath: "1-3"

--- a/packages/core/src/main.tsx
+++ b/packages/core/src/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import ChatbotEditor from './components/chatbot-editor'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <div className="w-full h-screen">
+      <ChatbotEditor />
+    </div>
+  </StrictMode>,
+)


### PR DESCRIPTION
## What Changed
Fixed inconsistent node labeling between FlowDiagram and NodeEditor. 
Updated FlowDiagram to display hierarchy paths (e.g., "Node 1-3-1") instead of simple node IDs (e.g., "Node 5") to match the NodeEditor display.

## Testing
- [ ] Added new tests
- [x] Existing tests pass
- [ ] Manually tested the changes

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Additional Notes

