### PR TITLE
fix: correct broken link to development page

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -160,7 +160,7 @@ const config: Config = {
             },
             {
               label: 'Development',
-              to: '/docs/Development',
+              to: '/docs/development',
             },
           ],
         },


### PR DESCRIPTION
## What Changed
- Fix navbar link /docs/Development → /docs/development
- Resolves GitHub Actions build failure"

## Testing
- [ ] Added new tests
- [x] Existing tests pass
- [ ] Manually tested the changes

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Additional Notes
<!-- Any additional information or context -->
