### PR TITLE
feat: improve node ID input and navigation UX

### DIFF
--- a/docs/docs/user-guide.md
+++ b/docs/docs/user-guide.md
@@ -14,6 +14,8 @@ The Chatbot Flow Editor interface consists of three main areas:
 - **Visual Flow Tree**: Hierarchical view of your conversation flow
 - **Node Navigation**: Click any node to select and edit it
 - **Flow Structure**: See the complete conversation tree at a glance
+- **Pan Navigation**: Click and drag empty space to move around large flows
+- **Scroll Support**: Use horizontal scrolling for wide conversation trees
 
 ### Right Panel: Split View (40%)
 - **Top Half**: Live chat preview for testing flows

--- a/packages/core/src/components/chatbot-editor/dialogs/EditOptionDialog.tsx
+++ b/packages/core/src/components/chatbot-editor/dialogs/EditOptionDialog.tsx
@@ -46,16 +46,19 @@ const EditOptionDialog: React.FC<EditOptionDialogProps> = ({
       return;
     }
     
-    const targetNodeId = parseInt(nextNodeId);
+    // Check if it's a numeric ID or hierarchyPath
+    const targetNode = flow.find(node => 
+      node.id.toString() === nextNodeId || 
+      node.hierarchyPath === nextNodeId
+    );
     
-    // Check if target node exists
-    if (!flow.some(node => node.id === targetNodeId)) {
+    if (!targetNode) {
       setError('The specified node ID does not exist');
       return;
     }
     
     // All validations passed
-    onSaveOption(optionLabel, targetNodeId);
+    onSaveOption(optionLabel, targetNode.id);
     setError(null);
   };
   
@@ -104,14 +107,11 @@ const EditOptionDialog: React.FC<EditOptionDialogProps> = ({
           <div className="flex space-x-2">
             <input
               className="w-full px-3 py-2 border rounded-md"
-              type="number"
+              type="text"
               value={nextNodeId}
               onChange={(e) => setNextNodeId(e.target.value)}
-              placeholder="Enter ID of the next node to display"
+              placeholder="Enter ID of the next node to display (e.g., 1-1-1)"
             />
-          </div>
-          <div className="text-sm text-gray-500">
-            Available IDs: {flow.map(n => n.id).join(', ')}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What Changed
  - Fixed EditOptionDialog to accept hierarchical node IDs (1-1-1-1)
  - Added dynamic width calculation for long node IDs in FlowDiagram
  - Implemented mouse drag pan navigation for large workflow trees

## Testing
- [ ] Added new tests
- [x] Existing tests pass
- [x] Manually tested the changes

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Additional Notes
  Improves UX for deep workflow hierarchies by enabling proper navigation and input
  handling for long node ID paths like 1-1-1-1-1-1-1-1-1-1-1.
