### PR TITLE
Release v0.1.3: Fix CLI 404 error with dedicated Vite configuration (…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatbot-flow-editor",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "A React-based chatbot flow editor library",
   "private": true,
   "workspaces": [

--- a/packages/core/bin/cli.js
+++ b/packages/core/bin/cli.js
@@ -6,7 +6,7 @@ import { dirname, join } from 'path'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const packageRoot = join(__dirname, '..')
 
-const vite = spawn('npx', ['vite', '--port', '3001', '--open'], {
+const vite = spawn('npx', ['vite', '--config', 'vite.cli.config.ts', '--port', '3001', '--open'], {
   cwd: packageRoot,
   stdio: 'inherit'
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatbot-flow-editor",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Visual chatbot flow editor - Development tool for creating conversational flows",
   "funding": "https://github.com/sponsors/enumura1",
   "type": "module",

--- a/packages/core/vite.cli.config.ts
+++ b/packages/core/vite.cli.config.ts
@@ -1,0 +1,23 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
+import tailwindcss from '@tailwindcss/vite'
+
+// Vite configuration for CLI development server
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+  ],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  // Standard dev server mode (lib mode disabled)
+  server: {
+    port: 3001,
+    open: true,
+  },
+})


### PR DESCRIPTION
## What Changed
- Fixed CLI 404 error by adding dedicated vite.cli.config.ts for development server
- Updated cli.js to use the new configuration file instead of library build config
- Bumped version from 0.1.1 to 0.1.3

## Testing
- [ ] Added new tests
- [x] Existing tests pass
- [x] Manually tested the changes

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Additional Notes
The CLI was previously failing with 404 errors because it was using the library build configuration which doesn't serve a development server.
