### PR TITLE
fix: display hierarchy paths instead of numeric IDs in node editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.2] - 2025-07-18
+
+### Fixed
+- Fix node display showing numeric IDs instead of hierarchy paths in NodeEditor
+- Fix EditOptionDialog default values showing numeric IDs instead of hierarchy paths
+- Now correctly displays "Option 1→ Node1-1" instead of "Option 1→ Node 2"
+
 ## [0.1.1] - 2025-07-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatbot-flow-editor",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatbot-flow-editor",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "workspaces": [
         "packages/*",
         "apps/*",
@@ -18820,7 +18820,7 @@
     },
     "packages/core": {
       "name": "@enumura/chatbot-flow-editor",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-scroll-area": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatbot-flow-editor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A React-based chatbot flow editor library",
   "private": true,
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enumura/chatbot-flow-editor",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Visual chatbot flow editor - Development tool for creating conversational flows",
   "funding": "https://github.com/sponsors/enumura1",
   "type": "module",

--- a/packages/core/src/components/chatbot-editor/NodeEditor.tsx
+++ b/packages/core/src/components/chatbot-editor/NodeEditor.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { ChatNode, ChatOption } from '../../types/chatbot';
+import { ChatNode, ChatOption, ChatbotFlow } from '../../types/chatbot';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -7,6 +7,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 
 interface NodeEditorProps {
   node: ChatNode;
+  flow: ChatbotFlow;
   onUpdateNode: (title: string) => void;
   onAddOption: () => void;
   onEditOption: (index: number) => void;
@@ -15,6 +16,7 @@ interface NodeEditorProps {
 
 const NodeEditor: React.FC<NodeEditorProps> = ({
   node,
+  flow,
   onUpdateNode,
   onAddOption,
   onEditOption,
@@ -33,6 +35,15 @@ const NodeEditor: React.FC<NodeEditorProps> = ({
   
   const handleSave = () => {
     onUpdateNode(title);
+  };
+  
+  // Helper function to get node display name from nextId
+  const getNodeDisplayName = (nextId: number): string => {
+    const targetNode = flow.find(n => n.id === nextId);
+    if (targetNode?.hierarchyPath) {
+      return `Node${targetNode.hierarchyPath}`;
+    }
+    return `Node ${nextId}`;
   };
   
   return (
@@ -86,7 +97,7 @@ const NodeEditor: React.FC<NodeEditorProps> = ({
                   <div key={idx} className="flex items-center justify-between bg-gray-50 p-3 rounded-md border border-gray-100">
                     <div className="text-sm truncate mr-2 flex-1">
                       <span className="font-medium">{opt.label}</span>
-                      <span className="text-gray-500 text-xs ml-2">→ Node {opt.nextId}</span>
+                      <span className="text-gray-500 text-xs ml-2">→ {getNodeDisplayName(opt.nextId)}</span>
                     </div>
                     <div className="flex gap-2 shrink-0">
                       <Button 

--- a/packages/core/src/components/chatbot-editor/index.tsx
+++ b/packages/core/src/components/chatbot-editor/index.tsx
@@ -277,6 +277,12 @@ export default function ChatbotEditor() {
     return null;
   }, [currentNode?.options, editingOptionIndex]);
   
+  // Helper function to get hierarchy path from nextId
+  const getHierarchyPathFromNextId = (nextId: number): string => {
+    const targetNode = flow.find(n => n.id === nextId);
+    return targetNode?.hierarchyPath || nextId.toString();
+  };
+  
   return (
     <div className="flex h-screen w-full bg-background text-foreground p-4 gap-4">
       {/* Left: Workflow diagram (60%) */}
@@ -331,6 +337,7 @@ export default function ChatbotEditor() {
         <div className="h-[calc(50%-8px)]">
           <NodeEditor 
             node={currentNode}
+            flow={flow}
             onUpdateNode={handleUpdateNode}
             onAddOption={handleOpenAddOption}
             onEditOption={handleEditOption}
@@ -357,7 +364,7 @@ export default function ChatbotEditor() {
           }}
           flow={flow}
           initialLabel={editingOption?.label || ''}
-          initialNextId={editingOption?.nextId.toString() || ''}
+          initialNextId={editingOption ? getHierarchyPathFromNextId(editingOption.nextId) : ''}
           isEditing={editingOptionIndex !== null}
           onSaveOption={handleSaveOption}
         />


### PR DESCRIPTION
  ## What Changed
  - Fixed NodeEditor to display hierarchy paths (e.g., "Node1-1") instead of numeric IDs
  (e.g., "Node 2")
  - Fixed EditOptionDialog default values to show hierarchy paths instead of numeric IDs
  - Added flow prop to NodeEditor component and helper function to convert nextId to
  hierarchy path
  - Bumped version to 0.1.2 and updated CHANGELOG.md

  ## Testing
  - [ ] Added new tests
  - [x] Existing tests pass
  - [x] Manually tested the changes

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Documentation update
  - [ ] Refactoring

## Additional Notes
fix https://github.com/enumura1/chatbot-flow-editor/issues/89
